### PR TITLE
fix(nh-ai-benchmark): workaround ArgoCD list merge issue for ingress [INFRA-82]

### DIFF
--- a/charts/nh-ai-benchmark/Chart.yaml
+++ b/charts/nh-ai-benchmark/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nh-ai-benchmark
 description: KAOPS addon to install NH AI Benchmark (API + UI)
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.1.0"
 
 dependencies:

--- a/charts/nh-ai-benchmark/config.yaml
+++ b/charts/nh-ai-benchmark/config.yaml
@@ -69,15 +69,6 @@ system:
   # UI nginx upstream — must match the API service name derived from the release name
   - path: "nh-ai-benchmark.ui.benchApiHost"
     value: "${system.cluster.name}-nh-ai-benchmark"
-  # Ingress hosts
-  - path: "nh-ai-benchmark.ingress.hosts[0].host"
-    value: "bench-api.${system.cluster.name}.${system.hubCluster.ingressHostname}"
-  - path: "nh-ai-benchmark.ingress.tls[0].hosts[0]"
-    value: "bench-api.${system.cluster.name}.${system.hubCluster.ingressHostname}"
-  - path: "nh-ai-benchmark.ui.ingress.hosts[0].host"
-    value: "bench.${system.cluster.name}.${system.hubCluster.ingressHostname}"
-  - path: "nh-ai-benchmark.ui.ingress.tls[0].hosts[0]"
-    value: "bench.${system.cluster.name}.${system.hubCluster.ingressHostname}"
   # OpenWebUI (standalone service, no cluster-name prefix)
   - path: "nh-ai-benchmark.env.OI_BASE_URL"
     value: "http://open-webui.nh-addons.svc.cluster.local"

--- a/charts/nh-ai-benchmark/values.yaml
+++ b/charts/nh-ai-benchmark/values.yaml
@@ -6,21 +6,12 @@ nh-ai-benchmark:
 
   ingress:
     enabled: true
-    className: "nginx"
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-prod
+      kubernetes.io/ingress.class: nginx
       kubernetes.io/tls-acme: "true"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    hosts:
-      - host: "" # system provided
-        paths:
-          - path: /
-            pathType: Prefix
-    tls:
-      - hosts:
-          - "" # system provided
-        secretName: nh-ai-benchmark-api-tls
 
   ui:
     enabled: true
@@ -29,21 +20,12 @@ nh-ai-benchmark:
     benchApiHost: "" # system provided
     ingress:
       enabled: true
-      className: "nginx"
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt-prod
+        kubernetes.io/ingress.class: nginx
         kubernetes.io/tls-acme: "true"
         nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
-      hosts:
-        - host: "" # system provided
-          paths:
-            - path: /
-              pathType: Prefix
-      tls:
-        - hosts:
-            - "" # system provided
-          secretName: nh-ai-benchmark-ui-tls
 
   # -- List of Kubernetes secret names to mount via envFrom.
   # Each secret's keys are injected as env var names, values as env var values.


### PR DESCRIPTION
ArgoCD fails with ComparisonError when merging YAML list objects (ingress hosts/tls). Fix: remove lists from values.yaml and config.yaml system section; set them manually via KAOPS advanced config web UI.