### PR TITLE
feat(private-ai-rag): prod hotfix-1 release 1.113.1

### DIFF
--- a/charts/private-ai-rag/Chart.yaml
+++ b/charts/private-ai-rag/Chart.yaml
@@ -15,14 +15,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.113.0
+version: 1.113.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 # NOTE: open webui was forked and this currently matches our release tag in the `values` file.
-appVersion: "v1.113.0"
+appVersion: "v1.113.1"
 
 dependencies:
   - name: open-webui

--- a/charts/private-ai-rag/Chart.yaml
+++ b/charts/private-ai-rag/Chart.yaml
@@ -22,7 +22,7 @@ version: 1.113.1
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 # NOTE: open webui was forked and this currently matches our release tag in the `values` file.
-appVersion: "v1.113.1"
+appVersion: "v1.113.0"
 
 dependencies:
   - name: open-webui

--- a/charts/private-ai-rag/values.yaml
+++ b/charts/private-ai-rag/values.yaml
@@ -519,7 +519,7 @@ nh-data-ingestion:
         cpu: 250m
         memory: 512Mi
     image:
-      tag: "v1.113.0"
+      tag: "v1.113.1"
   flower:
     resources:
       requests:

--- a/charts/private-ai-rag/values.yaml
+++ b/charts/private-ai-rag/values.yaml
@@ -529,7 +529,7 @@ nh-data-ingestion:
         cpu: 200m
         memory: 512Mi
     image:
-      tag: "v1.113.0"
+      tag: "v1.113.1"
   scheduler:
     resources:
       requests:
@@ -539,7 +539,7 @@ nh-data-ingestion:
         cpu: 200m
         memory: 256Mi
     image:
-      tag: "v1.113.0"
+      tag: "v1.113.1"
   worker:
     resources:
       requests:
@@ -549,7 +549,7 @@ nh-data-ingestion:
         cpu: 500m
         memory: 3Gi
     image:
-      tag: "v1.113.0"
+      tag: "v1.113.1"
   embedWorker:
     celery:
       concurrency: "6"
@@ -562,7 +562,7 @@ nh-data-ingestion:
         cpu: 1000m
         memory: 2Gi
     image:
-      tag: "v1.113.0"
+      tag: "v1.113.1"
     env:
       LLAMAINDEX_OLLAMA_BASE_URL: "http://open-webui-ollama:11434"
       OPEN_WEBUI_URL: "http://open-webui"


### PR DESCRIPTION
Prod hotfix-1 release 1.113.1. Bumps chart version 1.113.0 → 1.113.1, appVersion v1.113.0 → v1.113.1, and nh-data-ingestion image tag → v1.113.1.