### PR TITLE
feat(nh-ai-benchmark): enable EBS persistence (subchart 0.2.0) [INFRA-82]

### DIFF
--- a/charts/nh-ai-benchmark/Chart.yaml
+++ b/charts/nh-ai-benchmark/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: nh-ai-benchmark
 description: KAOPS addon to install NH AI Benchmark (API + UI)
 type: application
-version: 0.1.2
+version: 0.2.0
 appVersion: "0.1.0"
 
 dependencies:
   - name: nh-ai-benchmark
-    version: 0.1.1
+    version: 0.2.0
     repository: https://nethopper2.github.io/helm-charts/
     condition: nh-ai-benchmark.enabled


### PR DESCRIPTION
Bumps the nh-ai-benchmark subchart dependency to 0.2.0, which adds optional
EBS-backed persistence:

- results -> /app/results and workspace -> /app/prompts/workspace, both enabled by default
- default gp3 StorageClass, 1Gi each (grow-only), retainOnUninstall=true
- no wrapper override required; subchart defaults apply out of the box

[INFRA-82]


[INFRA-82]: https://nethopper.atlassian.net/browse/INFRA-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ