### PR TITLE
feat(nh-ai-benchmark): bump subchart to 0.2.1 for deploymentStrategy recreate [CORE-364]

### DIFF
--- a/charts/nh-ai-benchmark/Chart.yaml
+++ b/charts/nh-ai-benchmark/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: nh-ai-benchmark
 description: KAOPS addon to install NH AI Benchmark (API + UI)
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.1.0"
 
 dependencies:
   - name: nh-ai-benchmark
-    version: 0.2.0
+    version: 0.2.1
     repository: https://nethopper2.github.io/helm-charts/
     condition: nh-ai-benchmark.enabled


### PR DESCRIPTION
Bumps subchart dependency to 0.2.1 which adds Recreate deployment strategy for API (required for RWO PVCs).