### PR TITLE
feat(private-ai-rag): prod release 1.114.0

### DIFF
--- a/charts/private-ai-rag/Chart.yaml
+++ b/charts/private-ai-rag/Chart.yaml
@@ -15,14 +15,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.113.2
+version: 1.114.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 # NOTE: open webui was forked and this currently matches our release tag in the `values` file.
-appVersion: "v1.113.0"
+appVersion: "v1.114.0"
 
 dependencies:
   - name: open-webui

--- a/charts/private-ai-rag/values.yaml
+++ b/charts/private-ai-rag/values.yaml
@@ -70,7 +70,7 @@ open-webui:
       memory: 1536Mi
   image:
     repository: nethopper/kaops-open-webui
-    tag: "v1.113.0-slim"
+    tag: "v1.114.0-slim"
     pullPolicy: IfNotPresent
   ollama:
     fullnameOverride: "open-webui-ollama"
@@ -274,7 +274,7 @@ nh-rag-api:
       cpu: 1000m
       memory: 3Gi
   image:
-    tag: "v1.113.0"
+    tag: "v1.114.0"
   env:
     LLAMAINDEX_OLLAMA_BASE_URL: http://open-webui-ollama:11434
     QDRANT_URL: # system provided
@@ -414,7 +414,7 @@ nh-pai-data-service:
       cpu: 500m
       memory: 1Gi
   image:
-    tag: "v1.113.0"
+    tag: "v1.114.0"
   ingress:
     enabled: true
     annotations:
@@ -481,7 +481,7 @@ nh-mcp-server:
       cpu: 200m
       memory: 512Mi
   image:
-    tag: "v1.113.0"
+    tag: "v1.114.0"
   startupProbe:
     httpGet:
       path: /health
@@ -519,7 +519,7 @@ nh-data-ingestion:
         cpu: 250m
         memory: 512Mi
     image:
-      tag: "v1.113.1"
+      tag: "v1.114.0"
   flower:
     resources:
       requests:
@@ -529,7 +529,7 @@ nh-data-ingestion:
         cpu: 200m
         memory: 512Mi
     image:
-      tag: "v1.113.1"
+      tag: "v1.114.0"
   scheduler:
     resources:
       requests:
@@ -539,7 +539,7 @@ nh-data-ingestion:
         cpu: 200m
         memory: 256Mi
     image:
-      tag: "v1.113.1"
+      tag: "v1.114.0"
   worker:
     resources:
       requests:
@@ -549,7 +549,7 @@ nh-data-ingestion:
         cpu: 500m
         memory: 3Gi
     image:
-      tag: "v1.113.1"
+      tag: "v1.114.0"
   embedWorker:
     celery:
       concurrency: "6"
@@ -562,7 +562,7 @@ nh-data-ingestion:
         cpu: 1000m
         memory: 2Gi
     image:
-      tag: "v1.113.1"
+      tag: "v1.114.0"
     env:
       LLAMAINDEX_OLLAMA_BASE_URL: "http://open-webui-ollama:11434"
       OPEN_WEBUI_URL: "http://open-webui"


### PR DESCRIPTION
## Summary
Prod release **v1.114.0** for the `private-ai-rag` KAOPS addon, following the same pattern as the 1.111.0 (19ea4c4) and 1.113.0 (6564470) releases.

- `Chart.yaml`: `version` → `1.114.0`, `appVersion` → `v1.114.0`
- `values.yaml`: unified all nethopper app image tags to `v1.114.0`:
  - open-webui → `v1.114.0-slim`
  - nh-rag-api, nh-pai-data-service, nh-mcp-server → `v1.114.0`
  - nh-data-ingestion (worker/flower/scheduler/worker/embedWorker) → `v1.114.0` (were at the `v1.113.1` hotfix)

Third-party images (postgres, redis, curl) untouched. Diff: `Chart.yaml` 4 / `values.yaml` 18, matching prior releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)